### PR TITLE
Add restart always within docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ etcd:
   mem_limit: 128m
   labels:
     - triton.cns.services=etcd
+  restart: always
   environment:
     - DISCOVERY
   command: >-

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -10,6 +10,7 @@ services:
       - 2380
     links:
       - bootstrap:bootstrap
+    restart: always
     environment:
       - DISCOVERY
     command: >-


### PR DESCRIPTION
Straight forward. Recent updates forgot to add `restart: always` within the compose files. Taking heed of this [blog post's](https://www.joyent.com/blog/redis-on-autopilot) warning...

> Joyent recommends setting instances to always restart on Triton

/cc @misterbisson